### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -18,8 +18,10 @@ class ItemsController < ApplicationController
       render :new, status: :unprocessable_entity
     end
   end
-  
 
+  def show
+    @item = Item.find(params[:id])
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,9 +19,18 @@ class ItemsController < ApplicationController
     end
   end
 
+  def edit
+  end
+  
+  def update
+  end
+
   def show
     @item = Item.find(params[:id])
   end
+
+  def destroy
+  end  
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -135,7 +135,7 @@
          <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
           <%# 商品が売れていればsold outを表示 %>
-           <% if @items.present? %>
+           <% if @item.present? %>
            <div class='sold-out'>
              <span>Sold Out!!</span>
            </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -139,7 +139,7 @@
            <div class='sold-out'>
              <span>Sold Out!!</span>
            </div>
-          <% end %>
+           <% end %>
          </div>
          <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,15 +131,15 @@
     <%# 商品データがある場合は、eachメソッドで一覧表示 %>
     <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
          <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" if item.image.attached? %>
           <%# 商品が売れていればsold outを表示 %>
-           <%# if @items.present? %>
+           <% if @items.present? %>
            <div class='sold-out'>
              <span>Sold Out!!</span>
            </div>
-          <%# end %>
+          <% end %>
          </div>
          <div class='item-info'>
           <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,16 +28,16 @@
     <% if user_signed_in? %>
       <%# 出品者かつ未購入品であれば、編集・削除を表示 %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <%= link_to '商品の編集', '#', method: :get, class: "item-red-btn" %>
         <p class='or-text'>or</p>
-        <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
+        <%= link_to '削除', '#', method: :delete, class:'item-destroy' %>
       <%else%>
         <%= link_to '購入画面に進む', '#',class:"item-red-btn"%>
       <% end %>
     <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.product_description %></span>
     </div>
     <table class="detail-table">
       <tbody>
@@ -102,9 +102,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.product_category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.product_name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.delivery_charge.name %>
       </span>
     </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,12 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%# 商品が売れている場合は、sold outを表示 %>
+      <% if @items.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,19 +24,17 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <%# ログイン中であれば表示 %>
+    <% if user_signed_in? %>
+      <%# 出品者かつ未購入品であれば、編集・削除を表示 %>
+      <% if current_user.id == @item.user_id %>
+        <%= link_to '商品の編集', edit_item_path(@item), method: :get, class: "item-red-btn" %>
+        <p class='or-text'>or</p>
+        <%= link_to '削除', item_path(@item), method: :delete, class:'item-destroy' %>
+      <%else%>
+        <%= link_to '購入画面に進む', '#',class:"item-red-btn"%>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= "商品説明" %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -44,27 +44,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.product_category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.product_condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
 
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
What
商品詳細表示ページは誰でも見ることができる。商品一覧ページにて商品情報をクリックすると、商品の商品詳細表示ページへ遷移することができ、商品出品時に登録した情報がしっかりと表示される。「商品の編集」「削除」「購入画面に進む」ボタンの表示の有無が条件によってかわることができる。売却済みの商品は、画像上に「sold out」の文字が表示される。

Why
表示機能を振り分けることに見やすくすることを目的に実装。

https://gyazo.com/a742b00c35ab26d6ce5c26c58c403961
https://gyazo.com/d170cd68683b364c9433bb6e10368807
https://gyazo.com/1d75b157d4b104b10b3666b3da8ee383